### PR TITLE
Update Ruby Haml.tmlanguage with the version from textmate/ruby-haml.tmbundle

### DIFF
--- a/Syntaxes/Ruby Haml.tmLanguage
+++ b/Syntaxes/Ruby Haml.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -7,16 +7,27 @@
 		<string>haml</string>
 		<string>sass</string>
 	</array>
-	<key>foldingStartMarker</key>
-	<string>^\s*([-%#\:\.\w\=].*)\s$</string>
-	<key>foldingStopMarker</key>
-	<string>^\s*$</string>
 	<key>keyEquivalent</key>
 	<string>^~H</string>
 	<key>name</key>
 	<string>Ruby Haml</string>
 	<key>patterns</key>
 	<array>
+		<dict>
+			<key>begin</key>
+			<string>^\s*==</string>
+			<key>contentName</key>
+			<string>string.quoted.double.ruby</string>
+			<key>end</key>
+			<string>$\n?</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#interpolated_ruby</string>
+				</dict>
+			</array>
+		</dict>
 		<dict>
 			<key>captures</key>
 			<dict>
@@ -93,6 +104,21 @@
 			<string>$|(?!\.|#|\{|\[|=|-|~|/)</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>begin</key>
+					<string>==</string>
+					<key>contentName</key>
+					<string>string.quoted.double.ruby</string>
+					<key>end</key>
+					<string>$\n?</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#interpolated_ruby</string>
+						</dict>
+					</array>
+				</dict>
 				<dict>
 					<key>match</key>
 					<string>\.[\w-]+</string>
@@ -195,6 +221,131 @@
 			</dict>
 			<key>match</key>
 			<string>(\|)\s*\n</string>
+		</dict>
+		<key>interpolated_ruby</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.ruby</string>
+						</dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>source.ruby.embedded.source.empty</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>#\{(\})</string>
+					<key>name</key>
+					<string>source.ruby.embedded.source</string>
+				</dict>
+				<dict>
+					<key>begin</key>
+					<string>#\{</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.ruby</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(\})</string>
+					<key>name</key>
+					<string>source.ruby.embedded.source</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#nest_curly_and_self</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>source.ruby</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.variable.ruby</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(#@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.instance.ruby</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.variable.ruby</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(#@@)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.class.ruby</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.variable.ruby</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>(#\$)[a-zA-Z_]\w*</string>
+					<key>name</key>
+					<string>variable.other.readwrite.global.ruby</string>
+				</dict>
+			</array>
+		</dict>
+		<key>nest_curly_and_self</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>begin</key>
+					<string>\{</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.scope.ruby</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>\}</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#nest_curly_and_self</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>source.ruby</string>
+				</dict>
+			</array>
 		</dict>
 		<key>rubyline</key>
 		<dict>


### PR DESCRIPTION
Fixes #8 
- String interpolation syntax "==" now works
- Snippets are intact
